### PR TITLE
 Fix for #73 and #79

### DIFF
--- a/src/installer/bin/adapter-mgmt
+++ b/src/installer/bin/adapter-mgmt
@@ -247,9 +247,16 @@ class AdapterMgmtCLI(object):
     def create_resource_adapter_config(self, args): \
             # pylint: disable=no-self-use
 
+        if not args.setting:
+            sys.stderr.write(
+                'Error: No adapter configuration provided, '
+                'profile not created.\n'
+            )
+            sys.stdout.flush()
+            sys.exit(1)
+
         try:
             cfg = [dict(key=key, value=value) for key, value in args.setting]
-
             self.api.create(args.resource_adapter, args.profile, cfg)
         except TortugaException as exc:
             sys.stderr.write('Error: {0}\n'.format(exc))

--- a/src/installer/config/kickstart.tmpl
+++ b/src/installer/config/kickstart.tmpl
@@ -103,7 +103,12 @@ puppet_master_fqdn="{{ puppet_master_fqdn }}"
 
 touch /var/lock/subsys/tortuga.initialboot
 
-{% if installer_private_domain == domain %}
+{#
+ #  If the node has a domain name, and that domain name is different than
+ #  that of the installer, then we need to create a hosts record for the
+ #  puppet master.
+ #}
+{% if domain and installer_private_domain != domain %}
 # Add a host alias for the Puppet master using the private IP address for
 # hosts on the private (provisioning) network
 cat >>/etc/hosts <<ENDL


### PR DESCRIPTION
Don't add a host record for the puppet master if the node is on the same domain as the installer.