### PR TITLE
Move docker context to install directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,9 @@ install:
 script:
   - docker run -it --rm -v `pwd`:/tortuga univa/tortuga-builder tox -c src/core/tox.ini
   - docker run -it --rm -v `pwd`:/tortuga univa/tortuga-builder tox -c src/installer/tox.ini
-  - docker build -t univa/tortuga-build-kit:$TRAVIS_BUILD_NUMBER -f docker/Dockerfile.build-kit .
+  - docker run -it --rm -v `pwd`:/tortuga univa/tortuga-builder chown -R `id -u`:`id -g` ./install
+  - cp -f docker/Dockerfile.build-kit install
+  - docker build -t univa/tortuga-build-kit:$TRAVIS_BUILD_NUMBER -f ./install/Dockerfile.build-kit ./install
 deploy:
   - provider: script
     skip_cleanup: true

--- a/docker/Dockerfile.build-kit
+++ b/docker/Dockerfile.build-kit
@@ -1,6 +1,6 @@
 FROM univa/tortuga-builder
 
-ADD install/tortuga-*/tortuga_core-*.whl /
+ADD tortuga-*/tortuga_core-*.whl /
 RUN . /opt/rh/rh-python36/enable && \
     bash -c 'pip install wheel /tortuga_core-*.whl'
 WORKDIR /kit-src


### PR DESCRIPTION
We only include files from the install directory so move the
docker build context to that directory.