### PR TITLE
Docker friendly way of getting current user pw entry

### DIFF
--- a/src/installer/src/tortuga/os_objects/osBootHostManagerCommon.py
+++ b/src/installer/src/tortuga/os_objects/osBootHostManagerCommon.py
@@ -33,7 +33,11 @@ class OsBootHostManagerCommon(OsObjectManager):
         try:
             self.passdata = pwd.getpwnam('apache')
         except KeyError:
-            self.passdata = pwd.getpwnam(os.getenv('USER'))
+            username = os.getenv('USER')
+            if not username:
+                self.passdata = pwd.getpwuid(os.getuid())
+            else:
+                self.passdata = pwd.getpwnam(username)
 
         self._cm = ConfigManager()
 


### PR DESCRIPTION
Better handling when the `USER` environment variable is not set.