### PR TITLE
Fix travis build-kit build

### DIFF
--- a/docker/Dockerfile.build-kit
+++ b/docker/Dockerfile.build-kit
@@ -1,6 +1,6 @@
 FROM univa/tortuga-builder
 
-ADD tortuga-*/tortuga_core-*.whl /
+ADD tortuga-*/python-tortuga/tortuga_core-*.whl /
 RUN . /opt/rh/rh-python36/enable && \
     bash -c 'pip install wheel /tortuga_core-*.whl'
 WORKDIR /kit-src


### PR DESCRIPTION
This PR fixes the broken build with build-kit.  It was caused
by moving the built whl artifacts to a new directory.