### PR TITLE
Add aws cli to builder image

### DIFF
--- a/docker/Dockerfile.build-kit
+++ b/docker/Dockerfile.build-kit
@@ -2,6 +2,6 @@ FROM univa/tortuga-builder
 
 ADD tortuga-*/python-tortuga/tortuga_core-*.whl /
 RUN . /opt/rh/rh-python36/enable && \
-    bash -c 'pip install wheel /tortuga_core-*.whl'
+    bash -c 'pip install wheel awscli /tortuga_core-*.whl'
 WORKDIR /kit-src
 CMD [ "build-kit" ]


### PR DESCRIPTION
This allows easy staging of artifacts to s3 during kit builds