### PR TITLE
Refactor add-nodes parameter validation

### DIFF
--- a/src/core/src/tortuga/config/version.py
+++ b/src/core/src/tortuga/config/version.py
@@ -15,7 +15,7 @@
 from distutils.version import LooseVersion
 
 
-VERSION = '6.3.1-alpha+019'
+VERSION = '6.3.1-alpha+020'
 
 
 def version_is_compatible(version_string: str):

--- a/src/installer/src/tortuga/addhost/utility.py
+++ b/src/installer/src/tortuga/addhost/utility.py
@@ -102,15 +102,6 @@ def validate_addnodes_request(session: Session, addNodesRequest: Dict[str, Any])
 
         sp = hp.mappedsoftwareprofiles[0]
 
-    # Ensure user does not make a request for DHCP discovery mode.
-    # Currently, this is determined by the presence of the item
-    # 'nodeDetails' in addNodesRequest. Ultimately, this should be
-    # shared code between here and the default resource adapter.
-    if hp.resourceadapter and \
-            hp.resourceadapter.name == 'default' and not nodeDetails:
-        raise InvalidArgument(
-            'DHCP discovery is not available through WS API.')
-
     if sp and 'softwareProfile' not in addNodesRequest:
         addNodesRequest['softwareProfile'] = sp.name
 
@@ -133,24 +124,11 @@ def validate_addnodes_request(session: Session, addNodesRequest: Dict[str, Any])
             raise InvalidArgument(
                 'Hardware profile does not allow setting'
                 ' host names of imported nodes')
-        elif not hostname and bWildcardNameFormat:
-            # Host name not specified but hardware profile expects it
-            raise InvalidArgument(
-                'Hardware profile requires imported node'
-                ' name to be set')
 
         if nodeCount > 0 and nodeCount != len(nodeDetails):
             raise InvalidArgument(
                 'Node count must be equal to number'
                 ' of MAC/IP/node names provided')
-
-        if hostname:
-            # Ensure host does not already exist
-            existing_node = session.query(Node).filter(
-                Node.name == hostname).first()
-            if existing_node:
-                raise NodeAlreadyExists(
-                    'Node [%s] already exists' % (hostname))
 
     # check if software profile is locked
     if sp.lockedState:

--- a/src/installer/tests/test_DefaultResourceAdapter.py
+++ b/src/installer/tests/test_DefaultResourceAdapter.py
@@ -1,0 +1,144 @@
+# Copyright 2008-2018 Univa Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import patch
+
+import pytest
+
+from tortuga.db.hardwareProfilesDbHandler import HardwareProfilesDbHandler
+from tortuga.db.softwareProfilesDbHandler import SoftwareProfilesDbHandler
+from tortuga.exceptions.commandFailed import CommandFailed
+from tortuga.exceptions.nodeAlreadyExists import NodeAlreadyExists
+from tortuga.resourceAdapter.default import Default
+
+
+@patch('tortuga.node.nodeManager.osUtility.getOsObjectFactory')
+def test_without_software_profile(os_obj_factory_mock):
+    adapter = Default()
+
+    with pytest.raises(CommandFailed):
+        adapter.validate_start_arguments({}, None, None)
+
+
+@patch('tortuga.node.nodeManager.osUtility.getOsObjectFactory')
+def test_validate_start_arguments(os_obj_factory_mock, dbm):
+    with dbm.session() as session:
+        swprofile = SoftwareProfilesDbHandler().getSoftwareProfile(
+            session, 'compute')
+        hwprofile = HardwareProfilesDbHandler().getHardwareProfile(
+            session, 'localiron')
+
+        adapter = Default()
+        adapter.session = session
+
+        addNodesRequest = {}
+
+        # all 'default' nodes must have a 'nodeDetails' attribute in
+        # addNodesRequest
+        with pytest.raises(CommandFailed):
+            adapter.validate_start_arguments(
+                addNodesRequest, hwprofile, swprofile)
+
+
+@patch('tortuga.node.nodeManager.osUtility.getOsObjectFactory')
+def test_empty_nodeDetails(os_obj_factory_mock, dbm):
+    with dbm.session() as session:
+        swprofile = SoftwareProfilesDbHandler().getSoftwareProfile(
+            session, 'compute')
+        hwprofile = HardwareProfilesDbHandler().getHardwareProfile(
+            session, 'localiron')
+
+        adapter = Default()
+        adapter.session = session
+
+        addNodesRequest = {
+            'nodeDetails': [],
+        }
+
+        # all 'default' nodes must have a valid 'nodeDetails' attribute in
+        # addNodesRequest
+
+        with pytest.raises(CommandFailed):
+            adapter.validate_start_arguments(
+                addNodesRequest, hwprofile, swprofile)
+
+
+@patch('tortuga.node.nodeManager.osUtility.getOsObjectFactory')
+def test_duplicate_host_name(os_obj_factory_mock, dbm):
+    with dbm.session() as session:
+        swprofile = SoftwareProfilesDbHandler().getSoftwareProfile(
+            session, 'compute')
+        hwprofile = HardwareProfilesDbHandler().getHardwareProfile(
+            session, 'localiron')
+
+        adapter = Default()
+        adapter.session = session
+
+        addNodesRequest = {
+            'nodeDetails': [
+                {
+                    'name': 'compute-01.private',
+                }
+            ],
+        }
+
+        with pytest.raises(NodeAlreadyExists):
+            adapter.validate_start_arguments(
+                addNodesRequest, hwprofile, swprofile)
+
+@patch('tortuga.node.nodeManager.osUtility.getOsObjectFactory')
+def test_invalid_host_name_request(os_obj_factory_mock, dbm):
+    """
+    CommandFailed exception should be raised if attempting to add node to
+    hardware profile with name format set to "*" and without specifying a
+    host name.
+    """
+
+    with dbm.session() as session:
+        swprofile = SoftwareProfilesDbHandler().getSoftwareProfile(
+            session, 'compute')
+        hwprofile = HardwareProfilesDbHandler().getHardwareProfile(
+            session, 'localironalt')
+
+        adapter = Default()
+        adapter.session = session
+
+        with pytest.raises(CommandFailed):
+            adapter.validate_start_arguments({}, hwprofile, swprofile)
+
+@patch('tortuga.node.nodeManager.osUtility.getOsObjectFactory')
+def test_valid_host_name_request(os_obj_factory_mock, dbm):
+    with dbm.session() as session:
+        swprofile = SoftwareProfilesDbHandler().getSoftwareProfile(
+            session, 'compute')
+        hwprofile = HardwareProfilesDbHandler().getHardwareProfile(
+            session, 'localironalt')
+
+        adapter = Default()
+        adapter.session = session
+
+        addNodesRequest = {
+            'nodeDetails': [
+                {
+                    'name': 'myfakename',
+                    'nics': [
+                        {
+                        'mac': '00:00:00:00:00:01',
+                        },
+                    ]
+                }
+            ]
+        }
+
+        adapter.validate_start_arguments(addNodesRequest, hwprofile, swprofile)


### PR DESCRIPTION
- Tested for regression with on-premises and AWS resource adapters.
- Added unit tests for default resource adapter add nodes parameter validation