### PR TITLE
Puppet: bump tortuga_kit_base module version to 7.0.1

### DIFF
--- a/src/kits/kit-base/tortuga_kits/base_7_0_1/puppet_modules/tortuga_kit_base/manifests/params.pp
+++ b/src/kits/kit-base/tortuga_kits/base_7_0_1/puppet_modules/tortuga_kit_base/manifests/params.pp
@@ -16,7 +16,7 @@
 class tortuga_kit_base::params {
   $major_version = '7.0'
 
-  $kitvers = "${major_version}.0"
+  $kitvers = "${major_version}.1"
   $kititer = '0'
   $kitname = 'base'
 


### PR DESCRIPTION
Fixes minor issue with Puppet module run_post_install action.