### PR TITLE
Update URL out-of-support puppetlabs repositories to use archive

### DIFF
--- a/src/install-script/install-tortuga.sh
+++ b/src/install-script/install-tortuga.sh
@@ -375,7 +375,7 @@ function install_puppetlabs_repo {
 
     # install puppetlabs-release
     pkgexists puppetlabs-release || {
-        rpm_install http://release-archives.puppet.com/yum/el/$(distmajversion}/products/x86_64/puppetlabs-release-22.0-2.noarch.rpm
+        rpm_install http://release-archives.puppet.com/yum/el/${distmajversion}/products/x86_64/puppetlabs-release-22.0-2.noarch.rpm
         sed -i 's,http://yum.puppetlabs.com,http://release-archives.puppet.com/yum,' /etc/yum.repos.d/puppetlabs.repo
 
         pkgexists puppetlabs-release || {

--- a/src/install-script/install-tortuga.sh
+++ b/src/install-script/install-tortuga.sh
@@ -375,7 +375,8 @@ function install_puppetlabs_repo {
 
     # install puppetlabs-release
     pkgexists puppetlabs-release || {
-        rpm_install http://yum.puppetlabs.com/puppetlabs-release-el-${distmajversion}.noarch.rpm
+        rpm_install http://release-archives.puppet.com/yum/el/$(distmajversion}/products/x86_64/puppetlabs-release-22.0-2.noarch.rpm
+        sed -i 's,http://yum.puppetlabs.com,http://release-archives.puppet.com/yum,' /etc/yum.repos.d/puppetlabs.repo
 
         pkgexists puppetlabs-release || {
             echo "Error installing \"puppetlabs-release\". Unable to proceed." >&2


### PR DESCRIPTION
It is necessary to both change the URL for the RPM that creates the repo definitions in `/etc/yum.repos.d` AND to change the URL within the files in `/etc/yum.repos.d`. Files in `/etc/` are treated specially by `yum`/`rpm` in that they are allowed to be changed post-installation. This particular hack means that, if the release package ever gets upgraded, then the user will be prompted to accept the new version or keep the local changes. Then `.rpmold/.rpmnew` files might be created as a consequence of the user's choice.