### PR TITLE
Add proxy environment variables when installing pip package

### DIFF
--- a/src/kits/kit-base/tortuga_kits/base_7_0_3/puppet_modules/tortuga_kit_base/manifests/core/install.pp
+++ b/src/kits/kit-base/tortuga_kits/base_7_0_3/puppet_modules/tortuga_kit_base/manifests/core/install.pp
@@ -185,9 +185,19 @@ class tortuga_kit_base::core::install::install_tortuga_base {
 --trusted-host ${::primary_installer_hostname}"
   }
 
+  if $tortuga::config::proxy_uri {
+    $env = [
+      "https_proxy=${tortuga::config::proxy_uri}",
+      "http_proxy=${tortuga::config::proxy_uri}",
+    ]
+  } else {
+    $env = undef
+  }
+
   exec { 'install tortuga-core Python package':
     command => "${pipcmd} install ${pip_install_opts} tortuga-core",
     unless  => "${pipcmd} show tortuga-core",
+    environment => $env,
   }
 }
 


### PR DESCRIPTION
This update makes the `pip install` command similar to the other operations in this manifest in that it respects the configuration of a proxy.  When the proxy functionality is enabled the appropriate environment variable will be set when running `pip install`.