### PR TITLE
Allow celery to start after system reboots and wipes /run directory

### DIFF
--- a/src/puppet/univa-tortuga/templates/celery.service.erb
+++ b/src/puppet/univa-tortuga/templates/celery.service.erb
@@ -22,6 +22,7 @@ User=root
 Group=root
 EnvironmentFile=-<%= @instroot -%>/etc/celery
 WorkingDirectory=<%= @instroot %>
+ExecStartPre=-/bin/bash -c "/bin/mkdir -p $(dirname ${CELERYD_PID_FILE})"
 ExecStart=/bin/sh -c '${CELERY_BIN} multi start ${CELERYD_NODES} \
   -A ${CELERY_APP} --pidfile=${CELERYD_PID_FILE} \
   --logfile=${CELERYD_LOG_FILE} --loglevel=${CELERYD_LOG_LEVEL} ${CELERYD_OPTS}'


### PR DESCRIPTION
I believe this solution should work even if one starts multiple workers, so long as those workers create PID files in the same parent directory.

Look at [/opt/tortuga/etc/celery](https://github.com/UnivaCorporation/tortuga/blob/master/src/puppet/univa-tortuga/templates/celery.erb) to see the value of the variable that I'm using.

One needs to allow the `ExecStartPre` to fail in the instance that the directory already exists.