### PR TITLE
Update to address 5.5 deprecation warnings that will be fatal in Puppet 6

### DIFF
--- a/src/kits/kit-base/tortuga_kits/base_7_0_3/puppet_modules/tortuga_kit_base/manifests/installer/ntpd.pp
+++ b/src/kits/kit-base/tortuga_kits/base_7_0_3/puppet_modules/tortuga_kit_base/manifests/installer/ntpd.pp
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 
-class tortuga_kit_base::ntpd::package {
+class tortuga_kit_base::installer::ntpd::package {
   require tortuga::packages
 
   ensure_resource('package', 'ntp', { 'ensure' => 'installed'})
 }
 
-class tortuga_kit_base::ntpd::server {
-  require tortuga_kit_base::ntpd::package
+class tortuga_kit_base::installer::ntpd::server {
+  require tortuga_kit_base::installer::ntpd::package
 
   service { 'ntpd':
     enable => true,
@@ -30,7 +30,7 @@ class tortuga_kit_base::ntpd::server {
 
 class tortuga_kit_base::installer::ntpd ($enable = true) {
   if $enable {
-    contain tortuga_kit_base::ntpd::package
-    contain tortuga_kit_base::ntpd::server
+    contain tortuga_kit_base::installer::ntpd::package
+    contain tortuga_kit_base::installer::ntpd::server
   }
 }


### PR DESCRIPTION
These changes address the Puppet 6 requirement that class declarations "match" their filename.

https://groups.google.com/forum/#!topic/puppet-users/nxbwCvWrgMI

It is not necessary to backport this patch to installations that use Puppet 5.5, where they cause only a WARNing in the `puppetserver.log`.