### PR TITLE
Disable apache daemon listening on ports 80 and 443

### DIFF
--- a/src/puppet/univa-tortuga/manifests/installer/apache.pp
+++ b/src/puppet/univa-tortuga/manifests/installer/apache.pp
@@ -26,12 +26,17 @@ class tortuga::installer::apache::package {
 class tortuga::installer::apache::config {
   require tortuga::installer::apache::package
 
-  # Ensure SSLv3 is disabled by default (req'd for POODLE exploit)
-  augeas { 'disable_ssl_v3':
-    context => '/files/etc/httpd/conf.d/ssl.conf',
-    changes => 'set VirtualHost/directive[.="SSLProtocol"]/arg[last()+1] -SSLv3',
-    onlyif  => 'match VirtualHost/directive[.="SSLProtocol"][arg="-SSLv3"] size == 0',
+  file { '/etc/httpd/conf.d/ssl.conf':
+    ensure => absent,
+    notify => Service['httpd'],
   }
+
+  augeas { 'stop_listening_80':
+    context => '/files/etc/httpd/conf/httpd.conf',
+    changes => 'rm directive[.="Listen"]',
+    notify  => Service['httpd'],
+  }
+
 }
 
 class tortuga::installer::apache::server {


### PR DESCRIPTION
Tortuga installs the Apache HTTPD server and leaves around default configuration directives that cause it to be listening on ports 80 and 443 while serving content from `/var/www/html`. These do not appear to be in any danger of being used and actively interfere with running other services on standard ports (e.g. the Launch Web User Interface)