### PR TITLE
Increase Celery timeout to 6 hours

### DIFF
--- a/src/installer/src/tortuga/tasks/celery.py
+++ b/src/installer/src/tortuga/tasks/celery.py
@@ -27,7 +27,6 @@ from tortuga.kit.registry import get_all_kit_installers
 from tortuga.logging import ROOT_NAMESPACE, KIT_NAMESPACE
 from tortuga.objects.component import Component
 from tortuga.objects.kit import Kit
-from tortuga.objects.softwareProfile import SoftwareProfile
 from tortuga.softwareprofile.softwareProfileApi import SoftwareProfileApi
 from tortuga.types.application import Application
 from .task import TortugaTask

--- a/src/puppet/univa-tortuga/templates/celery.erb
+++ b/src/puppet/univa-tortuga/templates/celery.erb
@@ -40,7 +40,7 @@ CELERYD_MULTI="multi"
 #
 # Extra command-line arguments to the worker
 #
-CELERYD_OPTS="--time-limit=600 --concurrency=4"
+CELERYD_OPTS="--time-limit=21600 --concurrency=4"
 
 #
 # - %n will be replaced with the first part of the nodename.


### PR DESCRIPTION
This PR is so that Celery can handle processing large datasets without killing the worker.