### PR TITLE
Actively check for stale mysql connections

### DIFF
--- a/src/installer/src/tortuga/db/dbManager.py
+++ b/src/installer/src/tortuga/db/dbManager.py
@@ -56,7 +56,7 @@ class DbManager(TortugaObjectManager):
                 fd = os.open(schema, os.O_CREAT, mode=0o600)
                 os.close(fd)
 
-            self._engine = sqlalchemy.create_engine(engineURI)
+            self._engine = sqlalchemy.create_engine(engineURI, pool_pre_ping=True)
 
         else:
             self._engine = engine


### PR DESCRIPTION
Following the advice here:
https://stackoverflow.com/questions/6471549/avoiding-mysql-server-has-gone-away-on-infrequently-used-python-flask-server

Use the pool_pre_ping option to validate cached connections to
ensure they are still valid.