### PR TITLE
Use FQDN's in mcollective to match tortuga names

### DIFF
--- a/src/puppet/univa-tortuga/templates/server.cfg.tmpl
+++ b/src/puppet/univa-tortuga/templates/server.cfg.tmpl
@@ -15,6 +15,8 @@ daemonize = 1
 securityprovider = psk
 plugin.psk = unset
 
+identity = <%= @fqdn -%>
+
 connector = activemq
 plugin.activemq.pool.size = 1
 plugin.activemq.pool.1.host = <%= @puppet_server %>


### PR DESCRIPTION
With this commit the identities listed by mcollective can be be matched directly to tortuga names.