### PR TITLE
Should eliminate mod_cache_disk errors in internal Tortuga logs

### DIFF
--- a/src/kits/kit-base/tortuga_kits/base/puppet_modules/tortuga_kit_base/manifests/installer/apache.pp
+++ b/src/kits/kit-base/tortuga_kits/base/puppet_modules/tortuga_kit_base/manifests/installer/apache.pp
@@ -76,8 +76,15 @@ class tortuga_kit_base::installer::apache::config {
 
   $installer_fqdn = $tortuga::config::installer_fqdn
 
+  file { $cache_dir:
+    ensure => directory,
+    owner  => apache,
+    group  => apache,
+  }
+
   file { '/etc/httpd/conf.d/tortuga.conf':
     content => template('tortuga_kit_base/httpd.tortuga.conf.erb'),
+    require => File[$cache_dir],
   }
 }
 


### PR DESCRIPTION
The file `/var/log/httpd/tortugaint_error_log` is full of errors of the sort
```
[Mon Dec 30 18:07:31.816626 2019] [cache_disk:warn] [pid 19877] (2)No such file or directory: [client 10.0.202.195:39788] AH00725: could not create header file /var/cache/mod_proxy/aptmpj0bGLR
```
This PR should resolve these errors.