### PR TITLE
Skip hwprofile hostname validation if instructed

### DIFF
--- a/src/core/src/tortuga/config/version.py
+++ b/src/core/src/tortuga/config/version.py
@@ -15,7 +15,7 @@
 from distutils.version import LooseVersion
 
 
-VERSION = '7.1.0+003'
+VERSION = '7.1.0+004'
 
 
 def version_is_compatible(version_string: str):

--- a/src/installer/src/tortuga/addhost/utility.py
+++ b/src/installer/src/tortuga/addhost/utility.py
@@ -108,7 +108,8 @@ def validate_addnodes_request(session: Session,
         bWildcardNameFormat = hp.nameFormat == '*'
         hostname = nodeDetails[0]['name'] \
             if 'name' in nodeDetails[0] else None
-        if hostname and not bWildcardNameFormat:
+        if (hostname and not bWildcardNameFormat and not
+            addNodesRequest.get('skip_hostname_hwprofile_validation', False)):
             # Host name specified, but hardware profile does not
             # allow setting the host name
             raise InvalidArgument(


### PR DESCRIPTION
Validation of the `addNodesRequest` during instance self-registration will no longer fail if the hardware profile has a name format set and the `addNodesRequest` includes a hostname, if the `addNodesRequest` explicitly tells the validator to skip that check.