### PR TITLE
Show *all* exceptions in logs

### DIFF
--- a/src/installer/src/tortuga/addhost/addHostRequest.py
+++ b/src/installer/src/tortuga/addhost/addHostRequest.py
@@ -67,9 +67,8 @@ def process_addhost_request(session: Session, request: dict,
                 req.addHostSession
             )
         except Exception as exc:  # noqa pylint: disable=broad-except
-            if not isinstance(exc, TortugaException):
-                logger.exception(
-                    'Exception occurred during add host workflow')
+            logger.exception(
+                'Exception occurred during add host workflow')
 
             req.state = 'error'
             req.message = 'Exception: {}: {}'.format(

--- a/src/installer/src/tortuga/db/nodeDbApi.py
+++ b/src/installer/src/tortuga/db/nodeDbApi.py
@@ -103,9 +103,7 @@ class NodeDbApi(TagsDbApiMixin, TortugaDbApi):
                     include_installer=include_installer),
                 optionDict=optionDict)
         except Exception as ex:
-            if not isinstance(ex, TortugaException):
-                self._logger.exception(str(ex))
-
+            self._logger.exception(str(ex))
             raise
 
     def set_tags(self, session: Session, tags: Dict[str, str],

--- a/src/installer/src/tortuga/softwareprofile/softwareProfileApi.py
+++ b/src/installer/src/tortuga/softwareprofile/softwareProfileApi.py
@@ -295,11 +295,10 @@ class SoftwareProfileApi(TortugaApi): \
                 compVersion,
             )
         except Exception as ex:
+            self._logger.exception(
+                'Exception raised in {0}.enableComponent()'.format(
+                    self.__class__.__name__))
             if not isinstance(ex, TortugaException):
-                self._logger.exception(
-                    'Exception raised in {0}.enableComponent()'.format(
-                        self.__class__.__name__))
-
                 # Wrap exception
                 raise TortugaException(exception=ex)
 

--- a/src/installer/src/tortuga/sync/syncApi.py
+++ b/src/installer/src/tortuga/sync/syncApi.py
@@ -43,11 +43,12 @@ class SyncApi(TortugaApi):
         try:
             SyncManager().scheduleClusterUpdate(updateReason=updateReason, opts=opts)
         except Exception as ex:
+            self._logger.exception('Error scheduling cluster update')
+
             if isinstance(ex, TortugaException):
                 raise
 
-            self._logger.exception('Error scheduling cluster update')
-
+            # Wrap exception
             raise TortugaException(exception=ex)
 
     def getUpdateStatus(self):
@@ -61,9 +62,10 @@ class SyncApi(TortugaApi):
         try:
             return SyncManager().getUpdateStatus()
         except Exception as ex:
+            self._logger.exception('Error getting update status')
+
             if isinstance(ex, TortugaException):
                 raise
 
-            self._logger.exception('Error getting update status')
-
+            # Wrap exception
             raise TortugaException(exception=ex)

--- a/src/installer/src/tortuga/web_service/controllers/addHostController.py
+++ b/src/installer/src/tortuga/web_service/controllers/addHostController.py
@@ -86,12 +86,10 @@ class AddHostController(TortugaController):
              node['count'] = 1
              node['nodeDetails'] = [cherrypy.request.json.get('node_details')]
         except Exception as ex:
-            if not isinstance(ex, TortugaException):
-                if isinstance(ex, cryptography.fernet.InvalidToken):
-                    ex = TortugaException(args="InvalidToken")
-                else:
-                    self._logger.exception(
-                        'Exception occurred while adding hosts')
+            self._logger.exception('Exception occurred while adding hosts')
+
+            if isinstance(ex, cryptography.fernet.InvalidToken):
+                ex = TortugaException(args="InvalidToken")
 
             self.handleException(ex)
 
@@ -125,9 +123,7 @@ class AddHostController(TortugaController):
                     cherrypy.request.db, request),
             }
         except Exception as ex:  # pylint: disable=broad-except
-            if not isinstance(ex, TortugaException):
-                self._logger.exception(
-                    'Exception occurred while adding hosts')
+            self._logger.exception('Exception occurred while adding hosts')
 
             self.handleException(ex)
 


### PR DESCRIPTION
This commit makes `TortugaException`s and their tracebacks show up in the logs.

At present, this is not the case and I don't see any reason for it.  It makes debugging certain workflows (especially scale sets) very difficult because there are lots of silent failure modes.