### PR TITLE
Fix nfs dependency for Ubuntu/Debian

### DIFF
--- a/src/kits/kit-base/tortuga_kits/base/puppet_modules/tortuga_kit_base/manifests/common/nfs.pp
+++ b/src/kits/kit-base/tortuga_kits/base/puppet_modules/tortuga_kit_base/manifests/common/nfs.pp
@@ -33,7 +33,7 @@ class tortuga_kit_base::common::nfs::package {
 
   $pkgname = $::osfamily ? {
     'RedHat' => 'nfs-utils',
-    'Debian' => 'nfs-common',
+    'Debian' => 'nfs-kernel-server',
     default  => undef,
   }
 


### PR DESCRIPTION
The `nfs-common` package is only the client. To fully support our other kits, we need to install the full NFS server package.