### PR TITLE
Update requests package to the version actually installed during Launch installation

### DIFF
--- a/src/core/requirements.txt
+++ b/src/core/requirements.txt
@@ -4,5 +4,5 @@ marshmallow==2.16.3
 passlib==1.7.1
 pip2pi @ git+https://github.com/UnivaCorporation/pip2pi.git@univa-stable#egg=pip2pi-0.8.0
 python-dateutil==2.7.5
-requests==2.20.1
+requests~=2.23.0
 websockets==7.0

--- a/src/installer/requirements.txt
+++ b/src/installer/requirements.txt
@@ -4,7 +4,7 @@ pyyaml
 Routes==2.4.1
 SQLAlchemy==1.2.14
 celery==4.2.1
-cryptography==2.4.1
+cryptography~=2.8.0
 gevent==1.3.7
 kombu==4.2.1
 marshmallow-sqlalchemy==0.15.0


### PR DESCRIPTION
Due to the dependency of Navops Launch on `hvac==0.8.2`, the version of requests actually installed ends up being 2.23.0. We might as well bump our requirements to match reality.

Additionally, the installer's dependency on a 18-month old release of `cryptography` introduces a declared incompatibility between that and `paramiko`. Bump to latest release. This is the last version with support for OpenSSL 1.0.1. It is not immediately obvious whether the system OpenSSL is used or some internal pip library but it seems wise to pin on the last compatible version until we know how OpenSSL 1.1 compatibility is implemented.

```
ERROR: paramiko 2.7.1 has requirement cryptography>=2.5, but you'll have cryptography 2.4.1 which is incompatible.
```