### PR TITLE
Ensure Apache cache is reset when certificate authorities are updated

### DIFF
--- a/src/kits/kit-base/tortuga_kits/base/puppet_modules/tortuga_kit_base/manifests/installer/apache.pp
+++ b/src/kits/kit-base/tortuga_kits/base/puppet_modules/tortuga_kit_base/manifests/installer/apache.pp
@@ -53,7 +53,15 @@ class tortuga_kit_base::installer::apache::certs {
     owner   => apache,
     group   => apache,
     require => Exec['create_apache_x509_certificate'],
+    notify  => Exec['clean apache cache'],
   }
+
+  exec { 'clean apache cache':
+    path        => [ '/sbin', '/usr/sbin' ],
+    command     => "htcacheclean -l1B -p ${tortuga_kit_base::installer::apache::cache_dir}",
+    refreshonly => true,
+  }
+
 }
 
 class tortuga_kit_base::installer::apache::config {


### PR DESCRIPTION
The Apache `mod_cache_disk` is module is now working due to #597 . This has the "benefit" that  the certificate authority file being served over port 8008 to clients is cached even when the underlying file has changed.

This PR ensures that the cache is cleared when the CA is updated. It does have the impact of slightly reducing caching performance for the next client, but this is a benefit we've only had since #597 anyhow. We've been living with that performance for a while.

To see all URIs being cached at any given moment, you can run:
```
/sbin/htcacheclean -A -p /var/cache/mod_proxy/
```

(Verified and tested at customer site)