### PR TITLE
Ensure Apache cache is reset when certificate authorities are updated

### DIFF
--- a/src/kits/kit-base/tortuga_kits/base/puppet_modules/tortuga_kit_base/manifests/core/certificate_authority.pp
+++ b/src/kits/kit-base/tortuga_kits/base/puppet_modules/tortuga_kit_base/manifests/core/certificate_authority.pp
@@ -33,6 +33,14 @@ class tortuga_kit_base::core::certificate_authority {
     $dest_ca_cert = 'tortuga-ca.crt'
   }
 
+  if defined(Class['tortuga_kit_base::installer::apache::certs']) {
+    Class['tortuga_kit_base::installer::apache::certs'] -> File['ca-pem']
+  }
+
+  if defined(Class['tortuga::installer::apache::server']) {
+    Class['tortuga::installer::apache::server'] -> File['ca-pem']
+  }
+
   file { 'ca-pem':
     ensure => file,
     path   => "${ca_path}/${dest_ca_cert}",


### PR DESCRIPTION
This is the more "Puppet" way of doing what you're doing with the `test -d`