### PR TITLE
Eliminate installation of RedHat Software Collections when unnecessary

### DIFF
--- a/src/install-script/install-tortuga.sh
+++ b/src/install-script/install-tortuga.sh
@@ -781,14 +781,18 @@ pkgs+=" ${commonpkgs}"
 cachedpkgs+=" ${commonpkgs}"
 
 # only install 'centos-release-scl' when running normal installation
-[[ -z "${local_deps}" ]] && [[ ${dist} == centos ]] && {
-    echo "Installing SCL repository... "
-    installpkg centos-release-scl
-    [[ $? -eq 0 ]] || {
-        echo "Error installing \"centos-release-scl\". Unable to proceed." >&2
-        exit 1
-    }
-}
+if [[ -z "${local_deps}" ]] && [[ $distmajversion -eq 7 ]] && [[ $distminversion -le 6 ]]; then
+    if [[ ${dist} == centos ]]; then
+        echo "Installing SCL repository... "
+        installpkg centos-release-scl
+        [[ $? -eq 0 ]] || {
+            echo "Error installing \"centos-release-scl\". Unable to proceed." >&2
+            exit 1
+        }
+    elif [[ ${dist} == rhel ]]; then
+        subscription-manager repos --enable rhel-7-server-optional-rpms --enable rhel-server-rhscl-7-rpms
+    fi
+fi
 
 # download packages to local cache
 [[ $enable_package_caching -ne 0 ]] && cachepkgs ${commonpkgs}

--- a/src/install-script/install-tortuga.sh
+++ b/src/install-script/install-tortuga.sh
@@ -860,26 +860,6 @@ installpkgs ${pkgs}
 # Create Puppet modules directory, as necessary
 echo "Installing Puppet modules" | tee -a /tmp/install-tortuga.log
 
-# Install stdlib module from puppetlabs
-
-if [[ ${FORCE} -eq 1 ]] || ! is_puppet_module_installed puppetlabs-stdlib; then
-    echo "Installing puppetlabs-stdlib Puppet module..."
-
-    if [[ -n "${local_deps}" ]]; then
-        puppet_module_src="${local_deps}/puppet/puppetlabs-stdlib-5.2.0.tar.gz"
-    else
-        puppet_module_src="puppetlabs-stdlib --version 5.2.0"
-    fi
-
-    install_puppet_module ${puppet_module_src}
-    [[ $? -eq 0 ]] || {
-        echo "Error installing Puppet module \"puppetlabs-stdlib\"" | \
-            tee -a /tmp/install-tortuga.log
-
-        exit 1
-    }
-fi
-
 is_puppet_module_installed univa-tortuga || {
     echo "Installing Tortuga Puppet integration module..." | tee -a /tmp/install-tortuga.log
     install_puppet_module univa-tortuga-*.tar.gz

--- a/src/install-script/install-tortuga.sh
+++ b/src/install-script/install-tortuga.sh
@@ -506,18 +506,10 @@ function disto_patches() {
     esac
 }
 
-is_puppet_module_installed() {
-    /opt/puppetlabs/bin/puppet module list ${puppet_args} | grep --quiet "${1} "
-}
-
 install_puppet_module() {
     local install_args
 
     install_args="${puppet_args}"
-
-    if [[ ${FORCE} -eq 1 ]] || [[ -n "${local_deps}" ]]; then
-        install_args+=" --force"
-    fi
 
     /opt/puppetlabs/bin/puppet module install ${install_args} "$@"
 }
@@ -860,13 +852,16 @@ installpkgs ${pkgs}
 # Create Puppet modules directory, as necessary
 echo "Installing Puppet modules" | tee -a /tmp/install-tortuga.log
 
-is_puppet_module_installed univa-tortuga || {
-    echo "Installing Tortuga Puppet integration module..." | tee -a /tmp/install-tortuga.log
-    install_puppet_module univa-tortuga-*.tar.gz
-    [[ $? -eq 0 ]] || {
-        echo "Installation failed... unable to proceed" | tee -a /tmp/install-tortuga.log
-        exit 1
-    }
+echo "Installing Tortuga Puppet integration module..." | tee -a /tmp/install-tortuga.log
+
+if [[ ${FORCE} -eq 1 ]]; then
+    /opt/puppetlabs/bin/puppet module uninstall --force univa-tortuga
+fi
+
+install_puppet_module univa-tortuga-*.tar.gz
+[[ $? -eq 0 ]] || {
+    echo "Installation failed... unable to proceed" | tee -a /tmp/install-tortuga.log
+    exit 1
 }
 
 # source SCL Python 3.6 environment


### PR DESCRIPTION
And cleanup Puppet behavior when using `--force`. `puppet module install --force X` ignores all dependencies! Read commits for further details.

Tested on CentOS 7.7 and 7.4.1708 (a random older GCP image)

Resolves #624 