### PR TITLE
Update 7.1 branch with a cherry picking festival

### DIFF
--- a/src/install-script/install-tortuga.sh
+++ b/src/install-script/install-tortuga.sh
@@ -781,14 +781,18 @@ pkgs+=" ${commonpkgs}"
 cachedpkgs+=" ${commonpkgs}"
 
 # only install 'centos-release-scl' when running normal installation
-[[ -z "${local_deps}" ]] && [[ ${dist} == centos ]] && {
-    echo "Installing SCL repository... "
-    installpkg centos-release-scl
-    [[ $? -eq 0 ]] || {
-        echo "Error installing \"centos-release-scl\". Unable to proceed." >&2
-        exit 1
-    }
-}
+if [[ -z "${local_deps}" ]] && [[ $distmajversion -eq 7 ]] && [[ $distminversion -le 6 ]]; then
+    if [[ ${dist} == centos ]]; then
+        echo "Installing SCL repository... "
+        installpkg centos-release-scl
+        [[ $? -eq 0 ]] || {
+            echo "Error installing \"centos-release-scl\". Unable to proceed." >&2
+            exit 1
+        }
+    elif [[ ${dist} == rhel ]]; then
+        subscription-manager repos --enable rhel-7-server-optional-rpms --enable rhel-server-rhscl-7-rpms
+    fi
+fi
 
 # download packages to local cache
 [[ $enable_package_caching -ne 0 ]] && cachepkgs ${commonpkgs}

--- a/src/install-script/install-tortuga.sh
+++ b/src/install-script/install-tortuga.sh
@@ -860,26 +860,6 @@ installpkgs ${pkgs}
 # Create Puppet modules directory, as necessary
 echo "Installing Puppet modules" | tee -a /tmp/install-tortuga.log
 
-# Install stdlib module from puppetlabs
-
-if [[ ${FORCE} -eq 1 ]] || ! is_puppet_module_installed puppetlabs-stdlib; then
-    echo "Installing puppetlabs-stdlib Puppet module..."
-
-    if [[ -n "${local_deps}" ]]; then
-        puppet_module_src="${local_deps}/puppet/puppetlabs-stdlib-5.2.0.tar.gz"
-    else
-        puppet_module_src="puppetlabs-stdlib --version 5.2.0"
-    fi
-
-    install_puppet_module ${puppet_module_src}
-    [[ $? -eq 0 ]] || {
-        echo "Error installing Puppet module \"puppetlabs-stdlib\"" | \
-            tee -a /tmp/install-tortuga.log
-
-        exit 1
-    }
-fi
-
 is_puppet_module_installed univa-tortuga || {
     echo "Installing Tortuga Puppet integration module..." | tee -a /tmp/install-tortuga.log
     install_puppet_module univa-tortuga-*.tar.gz

--- a/src/install-script/install-tortuga.sh
+++ b/src/install-script/install-tortuga.sh
@@ -506,18 +506,10 @@ function disto_patches() {
     esac
 }
 
-is_puppet_module_installed() {
-    /opt/puppetlabs/bin/puppet module list ${puppet_args} | grep --quiet "${1} "
-}
-
 install_puppet_module() {
     local install_args
 
     install_args="${puppet_args}"
-
-    if [[ ${FORCE} -eq 1 ]] || [[ -n "${local_deps}" ]]; then
-        install_args+=" --force"
-    fi
 
     /opt/puppetlabs/bin/puppet module install ${install_args} "$@"
 }
@@ -860,13 +852,16 @@ installpkgs ${pkgs}
 # Create Puppet modules directory, as necessary
 echo "Installing Puppet modules" | tee -a /tmp/install-tortuga.log
 
-is_puppet_module_installed univa-tortuga || {
-    echo "Installing Tortuga Puppet integration module..." | tee -a /tmp/install-tortuga.log
-    install_puppet_module univa-tortuga-*.tar.gz
-    [[ $? -eq 0 ]] || {
-        echo "Installation failed... unable to proceed" | tee -a /tmp/install-tortuga.log
-        exit 1
-    }
+echo "Installing Tortuga Puppet integration module..." | tee -a /tmp/install-tortuga.log
+
+if [[ ${FORCE} -eq 1 ]]; then
+    /opt/puppetlabs/bin/puppet module uninstall --force univa-tortuga
+fi
+
+install_puppet_module univa-tortuga-*.tar.gz
+[[ $? -eq 0 ]] || {
+    echo "Installation failed... unable to proceed" | tee -a /tmp/install-tortuga.log
+    exit 1
 }
 
 # source SCL Python 3.6 environment

--- a/src/kits/kit-base/tortuga_kits/base/puppet_modules/tortuga_kit_base/manifests/core/certificate_authority.pp
+++ b/src/kits/kit-base/tortuga_kits/base/puppet_modules/tortuga_kit_base/manifests/core/certificate_authority.pp
@@ -33,6 +33,14 @@ class tortuga_kit_base::core::certificate_authority {
     $dest_ca_cert = 'tortuga-ca.crt'
   }
 
+  if defined(Class['tortuga_kit_base::installer::apache::certs']) {
+    Class['tortuga_kit_base::installer::apache::certs'] -> File['ca-pem']
+  }
+
+  if defined(Class['tortuga::installer::apache::server']) {
+    Class['tortuga::installer::apache::server'] -> File['ca-pem']
+  }
+
   file { 'ca-pem':
     ensure => file,
     path   => "${ca_path}/${dest_ca_cert}",

--- a/src/kits/kit-base/tortuga_kits/base/puppet_modules/tortuga_kit_base/manifests/installer/apache.pp
+++ b/src/kits/kit-base/tortuga_kits/base/puppet_modules/tortuga_kit_base/manifests/installer/apache.pp
@@ -48,21 +48,18 @@ class tortuga_kit_base::installer::apache::certs {
     require => Exec['create_apache_x509_certificate'],
   }
 
+  $ca_notify = $tortuga_kit_base::installer::apache::cache_enabled ? {
+    true    => Exec['clean apache cache'],
+    default => undef,
+  }
+
   file { "${tortuga::config::instroot}/www_int/ca.pem":
     source  => "${tortuga::config::instroot}/etc/CA/ca.pem",
     owner   => apache,
     group   => apache,
     require => Exec['create_apache_x509_certificate'],
-    notify  => Exec['clean apache cache'],
+    notify  => $ca_notify,
   }
-
-  exec { 'clean apache cache':
-    path        => [ '/sbin', '/usr/sbin' ],
-    command     => "htcacheclean -l1B -p ${tortuga_kit_base::installer::apache::cache_dir}",
-    onlyif      => "/bin/test -d ${tortuga_kit_base::installer::apache::cache_dir}",
-    refreshonly => true,
-  }
-
 }
 
 class tortuga_kit_base::installer::apache::config {
@@ -85,10 +82,20 @@ class tortuga_kit_base::installer::apache::config {
 
   $installer_fqdn = $tortuga::config::installer_fqdn
 
-  file { $cache_dir:
-    ensure => directory,
-    owner  => apache,
-    group  => apache,
+  if $cache_enabled {
+    file { $cache_dir:
+      ensure => directory,
+      owner  => apache,
+      group  => apache,
+    }
+
+    exec { 'clean apache cache':
+      user        => apache,
+      path        => [ '/sbin', '/usr/sbin' ],
+      command     => "htcacheclean -l1B -p ${cache_dir}",
+      refreshonly => true,
+      require     => File[$cache_dir],
+    }
   }
 
   file { '/etc/httpd/conf.d/tortuga.conf':


### PR DESCRIPTION
Adds following to 7.1 branch:

* Only install SCL repos when necessary (RHEL/CentOS 7.6 and below)
* better install script behavior for Puppet modules when run with `--force`
* Ensure proper order of Puppet resources when CA file is updated
* Do not fix version of `puppetlabs-stdlib` in install script because the version requirements are supplied in `univa-tortuga` puppet module metadata