### PR TITLE
Update modules to versions that support RHEL8

### DIFF
--- a/src/puppet/univa-tortuga/metadata.json
+++ b/src/puppet/univa-tortuga/metadata.json
@@ -10,12 +10,12 @@
   "project_page": "http://univa.com",
   "dependencies": [
     {
-      "version_requirement": "5.2.0",
-      "name": "puppetlabs/stdlib"
+      "version_requirement": ">= 2.9.0 < 3.0.0",
+      "name": "camptocamp/systemd"
     },
     {
-      "version_requirement": "2.6.0",
-      "name": "camptocamp/systemd"
+      "version_requirement": ">= 6.2.0 < 7.0.0",
+      "name": "puppetlabs/stdlib"
     }
   ]
 }


### PR DESCRIPTION
Update Puppet module dependencies to versions that declare support for RHEL8 and derivatives.

https://github.com/puppetlabs/puppetlabs-stdlib/blob/master/CHANGELOG.md#v620-2019-12-10
https://github.com/camptocamp/puppet-systemd/blob/master/CHANGELOG.md#290-2020-03-09

I am using the common approach to specify the minimum version while allowing for releases that do not declare API breaking changes.