### PR TITLE
Properly handle disabling Apache cache

### DIFF
--- a/src/kits/kit-base/tortuga_kits/base/puppet_modules/tortuga_kit_base/manifests/installer/apache.pp
+++ b/src/kits/kit-base/tortuga_kits/base/puppet_modules/tortuga_kit_base/manifests/installer/apache.pp
@@ -98,9 +98,14 @@ class tortuga_kit_base::installer::apache::config {
     }
   }
 
+  $conf_reqs = $cache_enabled ? {
+    true    => File[$cache_dir],
+    default => undef,
+  }
+
   file { '/etc/httpd/conf.d/tortuga.conf':
     content => template('tortuga_kit_base/httpd.tortuga.conf.erb'),
-    require => File[$cache_dir],
+    require => $conf_reqs,
   }
 }
 


### PR DESCRIPTION
The cache is probably useless since it's creating an on-disk cache
of... files already on the disk. The on-disk cache likely relies
on behavior of clients and server wrt ETag and other headers.