### PR TITLE
Refactor dnsmasq for improved performance

### DIFF
--- a/src/kits/kit-base/tortuga_kits/base/puppet_modules/tortuga_kit_base/manifests/dns.pp
+++ b/src/kits/kit-base/tortuga_kits/base/puppet_modules/tortuga_kit_base/manifests/dns.pp
@@ -16,7 +16,7 @@
 class tortuga_kit_base::dns (
   String $domain,
   String $server_type = 'dnsmasq',
-  Integer $local_ttl = 300,
+  Integer $local_ttl = 0,
 ) {
   include tortuga_kit_base::config
 

--- a/src/kits/kit-base/tortuga_kits/base/puppet_modules/tortuga_kit_base/manifests/dns.pp
+++ b/src/kits/kit-base/tortuga_kits/base/puppet_modules/tortuga_kit_base/manifests/dns.pp
@@ -16,6 +16,7 @@
 class tortuga_kit_base::dns (
   String $domain,
   String $server_type = 'dnsmasq',
+  Integer $local_ttl = 300,
 ) {
   include tortuga_kit_base::config
 
@@ -48,6 +49,7 @@ class tortuga_kit_base::dns::config {
   include tortuga_kit_base::config
 
   $domain = $tortuga_kit_base::dns::domain
+  $local_ttl = $tortuga_kit_base::dns::local_ttl
 
   # This is a workaround for a bug in Puppet/Augeas which cannot parse
   # /etc/resolv.conf containing a blank line with a leading semicolon

--- a/src/kits/kit-base/tortuga_kits/base/puppet_modules/tortuga_kit_base/metadata.json
+++ b/src/kits/kit-base/tortuga_kits/base/puppet_modules/tortuga_kit_base/metadata.json
@@ -9,12 +9,8 @@
   "issues_url": "http://suppport.univa.com",
   "description": "Tortuga Base kit integration module",
   "dependencies": [
-    {
-      "version_requirement": "5.2.0",
-      "name": "puppetlabs/stdlib"
-    },
-    {
-      "name": "puppetlabs/apt"
-    }
+    {"version_requirement": "5.2.0", "name": "puppetlabs/stdlib"},
+    {"name": "puppetlabs/apt"},
+    {"name":"camptocamp/systemd"}
   ]
 }

--- a/src/kits/kit-base/tortuga_kits/base/puppet_modules/tortuga_kit_base/templates/dnsmasq.conf.erb
+++ b/src/kits/kit-base/tortuga_kits/base/puppet_modules/tortuga_kit_base/templates/dnsmasq.conf.erb
@@ -14,3 +14,4 @@
 
 domain=<%= @domain %>
 hostsdir=/opt/tortuga/config/dnsmasq
+local-ttl=<%= @local_ttl %>

--- a/src/kits/kit-base/tortuga_kits/base/puppet_modules/tortuga_kit_base/templates/dnsmasq.conf.erb
+++ b/src/kits/kit-base/tortuga_kits/base/puppet_modules/tortuga_kit_base/templates/dnsmasq.conf.erb
@@ -12,6 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-server=/<%= dnszone -%>/127.0.0.1
-
-addn-hosts=/tmp/hosts.tortuga
+domain=<%= @domain %>
+hostsdir=/opt/tortuga/config/dnsmasq


### PR DESCRIPTION
This performance enhancement refactor does the following:
- Re-configures `dnsmasq` to monitor a directory (`/opt/tortuga/config/dnsmasq`) for hosts files. When a hosts file is added to this directory or changed, `dnsmasq` will detect the change and load the file without clearing the cache.
- For each node added, a file will be created `/opt/tortuga/config/dnsmasq/<hostname>`, with a hosts entry for that node
- For each node deleted, if a hosts file exists `/opt/tortuga/config/dnsmasq/<hostname>` exists it will be removed

Things to note:
- When hosts files are removed, `dnsmasq` will not remove the host record from it's cache until it is SIGHUP'd or restarted
- Any hosts files manually added to `/opt/tortuga/config/dnsmasq` that don't follow the naming pattern described above will also be read by `dnsmasq`, but not managed by Tortuga. This is an easy way to inject additional records if required.