### PR TITLE
Switch to UTC time for node timestamps

### DIFF
--- a/src/installer/src/tortuga/deployer/dbUtility.py
+++ b/src/installer/src/tortuga/deployer/dbUtility.py
@@ -38,7 +38,7 @@ def primeDb(session: Session, settings: Dict[str, Any]):
     node.state = state.NODE_STATE_INSTALLED
     node.lockedState = 'HardLocked'
     node.lastUpdate = time.strftime(
-        '%Y-%m-%d %H:%M:%S', time.localtime(time.time()))
+        '%Y-%m-%d %H:%M:%S', time.gmtime(time.time()))
     node.bootFrom = 1
 
     # Create Installer Software Profile

--- a/src/installer/src/tortuga/node/nodeManager.py
+++ b/src/installer/src/tortuga/node/nodeManager.py
@@ -370,7 +370,7 @@ class NodeManager(TortugaObjectManager): \
                 'Updated timestamp for node [%s]' % (dbNode.name))
 
         dbNode.lastUpdate = time.strftime(
-            '%Y-%m-%d %H:%M:%S', time.localtime(time.time()))
+            '%Y-%m-%d %H:%M:%S', time.gmtime(time.time()))
 
         result = bool(changed)
 

--- a/src/installer/src/tortuga/node/tasks.py
+++ b/src/installer/src/tortuga/node/tasks.py
@@ -125,6 +125,6 @@ def node_pinger():
         #
         for node in nodes:
             node.lastUpdate = time.strftime(
-                '%Y-%m-%d %H:%M:%S', time.localtime(time.time()))
+                '%Y-%m-%d %H:%M:%S', time.gmtime(time.time()))
 
         sess.commit()


### PR DESCRIPTION
Using local time made the actual time stored in the db ambiguous
as one wouldn't know the timezone at the time the record was
written.  With this change the dates will always be UTC and
consumers can perform the appropriate conversions.