### PR TITLE
Enabling templating of insertnode_request

### DIFF
--- a/src/installer/src/tortuga/resourceAdapter/userDataMixin.py
+++ b/src/installer/src/tortuga/resourceAdapter/userDataMixin.py
@@ -34,7 +34,8 @@ class UserDataMixin: \
     def expand_cloud_init_user_data_template(
             self, configDict: dict,
             node: Optional[Node] = None,
-            template=None) -> str:
+            template=None,
+            insertnode_request: Optional[bytes] = None) -> str:
         """
         Return cloud-init script template
 
@@ -62,6 +63,9 @@ class UserDataMixin: \
                                                   False),
             'dns_domain': configDict.get('dns_domain', ''),
         }
+
+        if insertnode_request:
+            tmpl_vars['insertnode_request'] = insertnode_request.decode('utf-8')
 
         if node:
             tmpl_vars['fqdn'] = node.name


### PR DESCRIPTION
cloud-init recipes do not presently have the ability to render the
insertnode_request variable which identifies the URI at which the
node must self-register upon boot. This is critical for instances
which are created "by AWS" rather than "by Launch" as in Spot and
Auto Scaling Groups.