### PR TITLE
Make sure the `_provider` field is initialized

### DIFF
--- a/src/kits/kit-base/tortuga_kits/base/components/dns/component.py
+++ b/src/kits/kit-base/tortuga_kits/base/components/dns/component.py
@@ -133,6 +133,7 @@ class ComponentInstaller(ComponentInstallerBase):
         Initialise parent class.
         """
         super().__init__(kit)
+        self._provider = None
 
     def action_get_puppet_args(self, db_software_profile,
                                db_hardware_profile,


### PR DESCRIPTION
A bug preventing the addtion of nodes when dns overrides were present
was introduced during the backport of the `Don't do DB query when
initializing DNS component`.  This change fixes the bug by making
sure the `_provider` field is initialized during object creation.