### PR TITLE
Remove debug logging of ws api http responses

### DIFF
--- a/src/core/src/tortuga/wsapi/client.py
+++ b/src/core/src/tortuga/wsapi/client.py
@@ -150,8 +150,6 @@ class RestApiClient:
         except Exception:
             pass
 
-        self._logger.debug('Response Payload: {}'.format(json.dumps(data)))
-
         return data
 
     def process_error_response(self, error_response: requests.Response):


### PR DESCRIPTION
The messages from the ws client can be too verbose even for
debug logging.  There are other ways to debug such information
that should be used if necessary.