### PR TITLE
Modernize Puppet module dependencies

### DIFF
--- a/src/puppet/univa-tortuga/metadata.json
+++ b/src/puppet/univa-tortuga/metadata.json
@@ -10,11 +10,11 @@
   "project_page": "http://univa.com",
   "dependencies": [
     {
-      "version_requirement": "5.2.0",
+      "version_requirement": "6.4.0",
       "name": "puppetlabs/stdlib"
     },
     {
-      "version_requirement": "2.6.0",
+      "version_requirement": "2.10.0",
       "name": "camptocamp/systemd"
     }
   ]


### PR DESCRIPTION
Update Puppet dependencies to recent releases of stdlib and systemd modules. This makes development of custom modules easier because 3rd party modules are likely to track updates. e.g. theforeman/puppet