### PR TITLE
Add MAX_TASKS_PER_CHILD setting to Celery

### DIFF
--- a/src/puppet/univa-tortuga/templates/celery.erb
+++ b/src/puppet/univa-tortuga/templates/celery.erb
@@ -43,6 +43,11 @@ CELERYD_MULTI="multi"
 # for embedded beat.
 #
 CELERYD_OPTS="--time-limit=21600 --concurrency=4 -B"
+#
+# Due to some potential memory leaks in Python/Celery, limit the number of
+# tasks a worker runs before restarting it
+#
+CELERYD_MAX_TASKS_PER_CHILD="100"
 
 #
 # - %n will be replaced with the first part of the nodename.


### PR DESCRIPTION
Fix for Celery memory leaks.