### PR TITLE
Include modernized logrotate configurations by default

### DIFF
--- a/src/installer/etc/celery.logrotate
+++ b/src/installer/etc/celery.logrotate
@@ -1,9 +1,8 @@
 /var/log/celery/*.log {
+    rotate 28
+    daily
+    compress
+    delaycompress
     missingok
     notifempty
-    sharedscripts
-    delaycompress
-    postrotate
-        /usr/sbin/service celery restart >/dev/null 2>/dev/null || true
-    endscript
 }

--- a/src/puppet/univa-tortuga/manifests/installer.pp
+++ b/src/puppet/univa-tortuga/manifests/installer.pp
@@ -37,6 +37,7 @@ class tortuga::installer (
   contain tortuga::installer::apache
   contain tortuga::installer::cfm
   contain tortuga::installer::sudo
+  contain tortuga::installer::basic
 
   class { 'tortuga::installer::database':
     database_engine => $database_engine_arg,


### PR DESCRIPTION
On Tortuga nodes, the celery and tortugawsd logs can become quite large. This PR adds (back) log rotation for these logs and modernizes the logrotate configuration for celery which no longer needs a service restart.

This code has been tested by running

```shell
/usr/sbin/logrotate -s /var/lib/logrotate/logrotate.status /etc/logrotate.conf --force
```

twice in a row. The first execution rotates the celery logs and creates files named like `w1-2.log-2020102620` and initially empty `w1-1.log` files. Manually creating a new node causes the `w1-1.log` to grow in size while those files with the timestamp stay the same size. The second execution causes the timestamped files to be gzipped.

The celery service was observed not to restart. The `tortugawsd` service did restart, but the configuration is such that it will restart once a week. We should see how important this is. You might look into this note from the celery changelog to see how difficult it is to avoid a restart:

* https://docs.celeryproject.org/en/stable/history/changelog-2.2.html#version-2-2-5
* https://github.com/celery/celery/blob/ea37db1410c83271e06d78a564983cba3732a1b1/celery/app/log.py#L13