### PR TITLE
Add check for existing node in addHosts

### DIFF
--- a/src/installer/src/tortuga/addhost/addHostManager.py
+++ b/src/installer/src/tortuga/addhost/addHostManager.py
@@ -67,14 +67,15 @@ class AddHostManager(TagsDbApiMixin, TortugaObjectManager):
         # a node. Instead, throw an exception so that callers can deal with
         # the problem in an appropriate fashion.
         #
-        node_details = addHostRequest.get('nodeDetails', {})
-        node_name = node_details.get('name', '').strip()
-        if node_name:
-            try:
-                self._nodeDbApi.getNode(session, node_name)
-                raise Exception("Node already exists: {}".format(node_name))
-            except NodeNotFound:
-                pass
+        node_details = addHostRequest.get('nodeDetails', [])
+        for node_detail in node_details:
+            node_name = node_detail.get('name', '').strip()
+            if node_name:
+                try:
+                    self._nodeDbApi.getNode(session, node_name)
+                    raise Exception("Node already exists: {}".format(node_name))
+                except NodeNotFound:
+                    pass
 
         dbHardwareProfile = \
             HardwareProfilesDbHandler().getHardwareProfile(

--- a/src/installer/src/tortuga/addhost/addHostManager.py
+++ b/src/installer/src/tortuga/addhost/addHostManager.py
@@ -27,6 +27,7 @@ from tortuga.db.nodeDbApi import NodeDbApi
 from tortuga.db.softwareProfilesDbHandler import SoftwareProfilesDbHandler
 from tortuga.db.tagsDbApiMixin import TagsDbApiMixin
 from tortuga.exceptions.notFound import NotFound
+from tortuga.exceptions.nodeNotFound import NodeNotFound
 from tortuga.exceptions.resourceAdapterNotFound import ResourceAdapterNotFound
 from tortuga.kit.actions import KitActionsManager
 from tortuga.logging import ADD_HOST_NAMESPACE
@@ -59,6 +60,21 @@ class AddHostManager(TagsDbApiMixin, TortugaObjectManager):
         """
 
         self._logger.debug('addHosts()')
+
+        #
+        # Check if a node with the same name already exists. If it does,
+        # then we should not go any further, as you cannot re-register
+        # a node. Instead, throw an exception so that callers can deal with
+        # the problem in an appropriate fashion.
+        #
+        node_details = addHostRequest.get('nodeDetails', {})
+        node_name = node_details.get('name', '').strip()
+        if node_name:
+            try:
+                self._nodeDbApi.getNode(session, node_name)
+                raise Exception("Node already exists: {}".format(node_name))
+            except NodeNotFound:
+                pass
 
         dbHardwareProfile = \
             HardwareProfilesDbHandler().getHardwareProfile(


### PR DESCRIPTION
If a node tries to register itself, and there is already a record in the DB with the same name, this results in a duplicate key error being thrown by the DB. The net result is that this condition can leave node requests in the pending/ADD state for ever as they are not properly cleaned-up.

This MR adds a check early-on in the addNode process to see if an existing node already exists with the same name. If it does, an exception is thrown immediately, allowing callers to deal with the repercussions before too much other processing has been done.